### PR TITLE
fix native app change detection for CodePush

### DIFF
--- a/appcenter-pre-build.sh
+++ b/appcenter-pre-build.sh
@@ -13,8 +13,8 @@ if [[ "$LAST_IOS" == "" ]]; then
   LAST_IOS=$(git log --max-parents=0 HEAD | grep -o -E -e "[0-9a-f]{40}")
 fi
 
-TRIGGER_ANDROID=$(git rev-list $LAST_ANDROID..$COMMIT_HASH | xargs -L1 git diff-tree --no-commit-id --name-only -r | grep "^android")
-TRIGGER_IOS=$(git rev-list $LAST_IOS..$COMMIT_HASH | xargs -L1 git diff-tree --no-commit-id --name-only -r | grep "^ios")
+TRIGGER_ANDROID=$(git diff --name-only $LAST_ANDROID..$COMMIT_HASH | grep "^android")
+TRIGGER_IOS=$(git diff --name-only $LAST_IOS..$COMMIT_HASH | grep "^ios")
 
 if [ ! -z "$GOOGLE_SERVICES_JSON" ]; then
   echo $GOOGLE_SERVICES_JSON | base64 --decode > "$APPCENTER_SOURCE_DIRECTORY/android/app/google-services.json"


### PR DESCRIPTION
Think we just want to grab files changed between the last native push eg $LAST_IOS and the current commit $COMMIT_HASH which I think is what `git diff --name-only $LAST_IOS..$COMMIT_HASH` does.

the prior git rev-list -> git diff-tree was pulling out files that didn't actually change between the two commits but had reverted changes made to them. So in the process of getting to $LAST_IOS eg Podfile changed but we reverted the changes in the end so it didn't actually change.